### PR TITLE
feat: util

### DIFF
--- a/.github/util.mjs
+++ b/.github/util.mjs
@@ -1,3 +1,12 @@
+/**
+ * node .github/util.mjs <command> [file]
+ * file can be a translation file you want to run the <command> against
+ * or a previous index.json to only run the <command> on the new added
+ * translations
+ * 
+ * e.g. node .github/util.mjs validate ./old_version/index.json
+ */
+
 import index from "../index.json" assert { type: "json" }
 import { readFileSync, writeFileSync, existsSync } from "fs"
 import { exit } from "process"

--- a/.github/util.mjs
+++ b/.github/util.mjs
@@ -41,13 +41,14 @@ const objToTranslation = (translation_obj) => JSON.stringify(translation_obj, nu
 const count = (str, sub) => str.split(sub).length - 1
 
 /**
- * Checks how many parameters are in source and translations
+ * Checks how many of `pattern` are in source and translations
  * so we can check if they match
  * @param {string} source The source value
  * @param {string} translation The translation value
+ * @param {string} pattern The pattern string to check (default: '{}')
  * @returns {{source: number, translation: number}}
  */
-const validateParams = (source, translation) => { return { source: count(source, "{}"), translation: count(translation, "{}") } }
+const patternCheck = (source, translation, pattern = "{}") => { return { source: count(source, pattern), translation: count(translation, pattern) } }
 
 const default_lang_file = `${index.default_lang}.json`
 const default_lang = translationToObj(default_lang_file)
@@ -76,6 +77,7 @@ const newTranslations = (oldTranslationFile) => {
  */
 const objHasAllKeys = (x, y) => Object.keys(x).length === Object.keys(y).length && Object.keys(x).every(z => y.hasOwnProperty(z))
 
+const patterns = ["{}", "%"]
 
 /**
  * Merges (and validates) translations based on the default one,
@@ -89,10 +91,12 @@ const mergeFunc = (translation) => {
 
     for (let key in translation_obj) {
         if (key in res_obj) {
-            const paramInfo = validateParams(default_lang[key], translation_obj[key])
-            if (paramInfo.source != paramInfo.translation) {
-                res.errors.push(`${translation}[${key}]: incorrect number of parameters (${paramInfo.source}:${paramInfo.translation})`)
-            }
+            patterns.forEach(pattern => {
+                const paramInfo = patternCheck(default_lang[key], translation_obj[key], pattern)
+                if (paramInfo.source != paramInfo.translation) {
+                    res.errors.push(`${translation}[${key}]: incorrect number of \`${pattern}\` found (${paramInfo.source}:${paramInfo.translation})`)
+                }
+            })
 
             res_obj[key] = translation_obj[key];
         }
@@ -113,10 +117,12 @@ const validateFunc = (translation) => {
 
     for (let key in translation_obj) {
         if (key in default_lang) {
-            const paramInfo = validateParams(default_lang[key], translation_obj[key])
-            if (paramInfo.source != paramInfo.translation) {
-                res.errors.push(`${translation}[${key}]: incorrect number of parameters (${paramInfo.source}:${paramInfo.translation})`)
-            }
+            patterns.forEach(pattern => {
+                const paramInfo = patternCheck(default_lang[key], translation_obj[key], pattern)
+                if (paramInfo.source != paramInfo.translation) {
+                    res.errors.push(`${translation}[${key}]: incorrect number of \`${pattern}\` found (${paramInfo.source}:${paramInfo.translation})`)
+                }
+            })
 
             if (default_lang[key] === translation_obj[key]) {
                 res.warnings.push(`${translation}[${key}]: might be untranslated`)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,22 @@ jobs:
           path: old
 
       - name: Run util validate
-        run: node .github/util.mjs validate old/index.json
+        run: |
+          node .github/util.mjs validate old/index.json
+          mv .result.json .result.json.validate
+
+      - name: Run util merge
+        continue-on-error: true
+        run: |
+          cmp --silent ./en_US.json ./old/en_US.json || node .github/util.mjs merge
+          [ -f .result.json ] || exit 0
+          cat .result.json
+          mv .result.json .result.json.merge
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ./*.json
+          git commit -m "chore: merge translations" || exit 0
+          git push ${{ github.event.pull_request.head.repo.html_url }} ${{ github.event.pull_request.head.ref }}
 
       - name: Post util validate
         uses: actions/github-script@v6
@@ -25,7 +40,10 @@ jobs:
           script: |
             const fs = require('fs');
             const process = require('process');
-            const result = JSON.parse(fs.readFileSync(".result.json"));
+            const result = JSON.parse(fs.readFileSync(".result.json.validate"));
+            if (fs.existsSync(".result.json.merge")) {
+              result.changed = [...result.changed, ...JSON.parse(fs.readFileSync(".result.json.merge")).changed];
+            }
             if (result.changed?.length === 0 && result.errors?.length === 0 && result.warnings?.length === 0) process.exit(0)
             const {owner, repo} = context.repo;
             const pull_request = ${{ github.event.number }};
@@ -33,45 +51,16 @@ jobs:
               return core.error("This workflow doesn't match any pull requests!");
             }
 
-            const errors = [`
-              > <picture>
-              >   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/f4116f5b4a31c72fcfdd5cb9869bb4ae2a2cf4a8/blockquotes/badge/light-theme/error.svg">
-              >   <img alt="Error" src="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/f4116f5b4a31c72fcfdd5cb9869bb4ae2a2cf4a8/blockquotes/badge/dark-theme/error.svg">
-              > </picture><br>`]
+            const labels = {
+              changed: "info",
+              warnings: "warning",
+              errors: "error"
+            }
 
-            result.errors.forEach(error => {
-              errors.push(`> ${error}`)
-            })
+            const generate_md = (label, results) => results.length > 0 ? `<details><summary><picture><source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/f4116f5b4a31c72fcfdd5cb9869bb4ae2a2cf4a8/blockquotes/badge/light-theme/${label}.svg"><img alt="${label}" src="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/f4116f5b4a31c72fcfdd5cb9869bb4ae2a2cf4a8/blockquotes/badge/dark-theme/${label}.svg"></picture> (${results.length})</summary>\n\n\`\`\`\n${results.join("\n")}\n\`\`\`\n\n</details>` : ""
 
-            const warnings = ["> **Warning**"]
+            let body = [];
+            ["changed", "warnings", "errors"].forEach(x => body.push(generate_md(labels[x], result[x])));
+            body = body.filter(x => x.length > 0);
 
-            result.warnings.forEach(warn => {
-              warnings.push(`> ${warn}`)
-            })
-
-            const infos = ["> **Note**"]
-
-            result.changed.forEach(info => {
-              infos.push(`> ${info}`)
-            })
-
-            const body = `
-              ${infos.length > 1 ? infos.join("\n") : ""}
-
-              ${warnings.length > 1 ? warnings.join("\n") : ""}
-
-              ${errors.length > 1 ? errors.join("\n") : ""}
-            `
-
-            await github.rest.issues.createComment({ owner, repo, issue_number: pull_request, body });
-
-      - name: Run util merge
-        run: |
-          rm .result.json
-          cmp --silent ./en_US.json ./old/en_US.json || node .github/util.mjs merge
-          [ -f .result.json ] || exit 0
-          git config --local user.name "github-actions[bot]"
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git add ./*.json
-          git commit -m "chore: merge translations" || exit 0
-          git push
+            await github.rest.issues.createComment({ owner, repo, issue_number: pull_request, body: body.join("\n") });

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+name: CI
+
+on: pull_request
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+    name: CI
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          repository: ${{ github.event.pull_request.head.repo.full_name }}
+          ref: ${{ github.event.pull_request.head.ref }}
+      - uses: actions/checkout@v3
+        with:
+          ref: master
+          path: old
+
+      - name: Run util validate
+        run: node .github/util.mjs validate old/index.json
+
+      - name: Post util validate
+        uses: actions/github-script@v6
+        with:
+          script: |
+            const fs = require('fs');
+            const process = require('process');
+            const result = JSON.parse(fs.readFileSync(".result.json"));
+            if (result.changed?.length === 0 && result.errors?.length === 0 && result.warnings?.length === 0) process.exit(0)
+            const {owner, repo} = context.repo;
+            const pull_request = ${{ github.event.number }};
+            if (!pull_request) {
+              return core.error("This workflow doesn't match any pull requests!");
+            }
+
+            const errors = [`
+              > <picture>
+              >   <source media="(prefers-color-scheme: light)" srcset="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/f4116f5b4a31c72fcfdd5cb9869bb4ae2a2cf4a8/blockquotes/badge/light-theme/error.svg">
+              >   <img alt="Error" src="https://raw.githubusercontent.com/Mqxx/GitHub-Markdown/f4116f5b4a31c72fcfdd5cb9869bb4ae2a2cf4a8/blockquotes/badge/dark-theme/error.svg">
+              > </picture><br>`]
+
+            result.errors.forEach(error => {
+              errors.push(`> ${error}`)
+            })
+
+            const warnings = ["> **Warning**"]
+
+            result.warnings.forEach(warn => {
+              warnings.push(`> ${warn}`)
+            })
+
+            const infos = ["> **Note**"]
+
+            result.changed.forEach(info => {
+              infos.push(`> ${info}`)
+            })
+
+            const body = `
+              ${infos.length > 1 ? infos.join("\n") : ""}
+
+              ${warnings.length > 1 ? warnings.join("\n") : ""}
+
+              ${errors.length > 1 ? errors.join("\n") : ""}
+            `
+
+            await github.rest.issues.createComment({ owner, repo, issue_number: pull_request, body });
+
+      - name: Run util merge
+        run: |
+          rm .result.json
+          cmp --silent ./en_US.json ./old/en_US.json || node .github/util.mjs merge
+          [ -f .result.json ] || exit 0
+          git config --local user.name "github-actions[bot]"
+          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
+          git add ./*.json
+          git commit -m "chore: merge translations" || exit 0
+          git push

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+.result.json

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .result.json
+.result.json.*

--- a/util.mjs
+++ b/util.mjs
@@ -101,9 +101,15 @@ if (command === undefined || !commandNames.includes(command)) {
     exit(1)
 }
 
-translations.forEach(translation => {
-    commands[command](translation)
-})
+/** @type {string?} */
+const arg = process.argv[3]
+if (!!arg && translations.includes(arg)) {
+    commands[command](arg)
+} else {
+    translations.forEach(translation => {
+        commands[command](translation)
+    })
+}
 
 console.log(res)
 writeFileSync(".result.json", objToTranslation(res))

--- a/util.mjs
+++ b/util.mjs
@@ -5,7 +5,8 @@ import { exit } from "process"
 /** @type {{changed: string[], errors: string[]}} */
 const res = {
     changed: [],
-    errors: []
+    errors: [],
+    warnings: []
 }
 
 /**
@@ -82,6 +83,10 @@ const validateFunc = (translation) => {
             const paramInfo = validateParams(default_lang[key], translation_obj[key])
             if (paramInfo.source != paramInfo.translation) {
                 res.errors.push(`${translation}[${key}]: incorrect number of parameters (${paramInfo.source}:${paramInfo.translation})`)
+            }
+
+            if (default_lang[key] === translation_obj[key]) {
+                res.warnings.push(`${translation}[${key}]: might be untranslated`)
             }
         }
     }

--- a/util.mjs
+++ b/util.mjs
@@ -1,0 +1,109 @@
+import index from "./index.json" assert { type: "json" }
+import { readFileSync, writeFileSync } from "fs"
+import { exit } from "process"
+
+/** @type {{changed: string[], errors: string[]}} */
+const res = {
+    changed: [],
+    errors: []
+}
+
+/**
+ * Reads the translation_file and returns it as an object
+ * @param {string} translation_file Translation file with extension (e.g. .json)
+ * @returns {object}
+ */
+const translationToObj = (translation_file) => JSON.parse(readFileSync(`./${translation_file}`, { encoding: "utf-8" }))
+
+/**
+ * Stringifies the translation_obj with 4-space indent
+ * @param {object} translation_obj The translation object
+ * @returns {string}
+ */
+const objToTranslation = (translation_obj) => JSON.stringify(translation_obj, null, 4)
+
+/**
+ * Counts how many times sub occurs in str
+ * @param {string} str The source string
+ * @param {string} sub The substring
+ * @returns {number}
+ */
+const count = (str, sub) => str.split(sub).length - 1
+
+/**
+ * Checks how many parameters are in source and translations
+ * so we can check if they match
+ * @param {string} source The source value
+ * @param {string} translation The translation value
+ * @returns {{source: number, translation: number}}
+ */
+const validateParams = (source, translation) => { return { source: count(source, "{}"), translation: count(translation, "{}") } }
+
+const default_lang_file = `${index.default_lang}.json`
+const default_lang = translationToObj(default_lang_file)
+const translations = Object.values(index.translations).map(x => x.file).filter(x => x != default_lang_file)
+
+/**
+ * Merges (and validates) translations based on the default one,
+ * so if keys get removed or added they also do in all the other
+ * translations
+ * @param {string} translation The translation file name including its extension
+ */
+const mergeFunc = (translation) => {
+    const translation_obj = translationToObj(translation)
+    const res_obj = { ...default_lang }
+
+    for (let key in translation_obj) {
+        if (key in res_obj) {
+            const paramInfo = validateParams(default_lang[key], translation_obj[key])
+            if (paramInfo.source != paramInfo.translation) {
+                res.errors.push(`${translation}[${key}]: incorrect number of parameters (${paramInfo.source}:${paramInfo.translation})`)
+            }
+
+            res_obj[key] = translation_obj[key];
+        }
+    }
+
+    if (Object.keys(res_obj).length !== Object.keys(translation_obj).length) {
+        writeFileSync(translation, objToTranslation(res_obj))
+        res.changed.push(translation)
+    }
+}
+
+/**
+ * Validates the translation against the default on
+ * @param {string} translation The translation file name including its extension
+ */
+const validateFunc = (translation) => {
+    const translation_obj = translationToObj(translation)
+
+    for (let key in translation_obj) {
+        if (key in default_lang) {
+            const paramInfo = validateParams(default_lang[key], translation_obj[key])
+            if (paramInfo.source != paramInfo.translation) {
+                res.errors.push(`${translation}[${key}]: incorrect number of parameters (${paramInfo.source}:${paramInfo.translation})`)
+            }
+        }
+    }
+}
+
+const commands = {
+    merge: mergeFunc,
+    validate: validateFunc
+}
+
+/** @type {string?} */
+const command = process.argv[2]?.toLowerCase()
+const commandNames = Object.keys(commands)
+if (command === undefined || !commandNames.includes(command)) {
+    const msg = command === undefined ? "No command provided" : `Command "${command}" does not exist`
+    console.log(`${msg}\nAvailable commands: ${commandNames.join(", ")}`)
+    exit(1)
+}
+
+translations.forEach(translation => {
+    commands[command](translation)
+})
+
+console.log(res)
+writeFileSync(".result.json", objToTranslation(res))


### PR DESCRIPTION
A quick util tool to merge and validate translations.

Ideally the validate command should run on PRs and the merge one when there's a change to the default lang.

Validate just checks if the amount of params in the translation is the same as the one in the default on (e.g. `test {} {}` vs `test {}`).

Merge adds/removes strings on all translations based on the default one.

Example runs:

- `node util.mjs validate`

```js
{
  changed: [],
  errors: [
    'zh_CN.json[REMOTE_CRASH_INVALID_TRANSITION_FROM]: incorrect number of parameters (1:2)',
    'zh_CN.json[REMOTE_CRASH_INVALID_BLACKLIST_FROM]: incorrect number of parameters (1:2)'
  ]
}
```

- `node util.mjs merge`

```js
{
  changed: [ 'en_LOL.json', 'zh_CN.json', 'zh_TW.json' ],
  errors: [
    'zh_CN.json[REMOTE_CRASH_INVALID_TRANSITION_FROM]: incorrect number of parameters (1:2)',
    'zh_CN.json[REMOTE_CRASH_INVALID_BLACKLIST_FROM]: incorrect number of parameters (1:2)'
  ]
}
```